### PR TITLE
Add SMIME encryption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,14 +126,16 @@ No provider.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| algorithm | The algorithm to use, RSA or SMIME. | `string` | `"RSA"` | no |
+| cert\_pem | The (self-)signed certificate if using SMIME. | `string` | `null` | no |
 | content\_base64 | Base64-encoded data to be encrypted. | `string` | n/a | yes |
-| public\_key\_pem | The RSA public key to use for encryption. | `string` | n/a | yes |
+| public\_key\_pem | The RSA public key to use for encryption. | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| result | Encrypted content in Base64-encoded format. |
+| result | The base64-encoded encrypted content. |
 
 <!-- markdownlint-restore -->
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -15,13 +15,15 @@ No provider.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| algorithm | The algorithm to use, RSA or SMIME. | `string` | `"RSA"` | no |
+| cert\_pem | The (self-)signed certificate if using SMIME. | `string` | `null` | no |
 | content\_base64 | Base64-encoded data to be encrypted. | `string` | n/a | yes |
-| public\_key\_pem | The RSA public key to use for encryption. | `string` | n/a | yes |
+| public\_key\_pem | The RSA public key to use for encryption. | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| result | Encrypted content in Base64-encoded format. |
+| result | The base64-encoded encrypted content. |
 
 <!-- markdownlint-restore -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,12 @@ resource "tls_private_key" "this" {
 }
 
 resource "random_password" "this" {
-  length = 16
+  length = 128
+}
+
+output "generated" {
+  description = "The random generated password."
+  value       = random_password.this.result
 }
 
 module "encrypt" {
@@ -13,14 +18,33 @@ module "encrypt" {
   content_base64 = base64encode(random_password.this.result)
 }
 
-
-output "generated" {
-  description = "The random generated password."
-  value       = random_password.this.result
+resource "tls_self_signed_cert" "this" {
+  key_algorithm         = tls_private_key.this.algorithm
+  private_key_pem       = tls_private_key.this.private_key_pem
+  validity_period_hours = 1
+  subject {
+    common_name = "test"
+  }
+  allowed_uses = [
+    "key_encipherment"
+  ]
 }
+
+module "smime-encrypt" {
+  source = "../.."
+
+  algorithm      = "SMIME"
+  cert_pem       = tls_self_signed_cert.this.cert_pem
+  content_base64 = filebase64("main.tf")
+}
+
 
 output "decrypted" {
   description = "The same random password after it was encrypted and then decrypted."
   value       = rsadecrypt(module.encrypt.result, tls_private_key.this.private_key_pem)
+}
+
+output "smime_der_b64" {
+  value = module.smime-encrypt.result
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,18 @@
+locals {
+  openssl_command = {
+    RSA   = "rsautl -encrypt -pubin -inkey $public_key_pem_file"
+    SMIME = "smime -binary -encrypt -aes-256-cbc -outform DER $public_key_pem_file"
+  }
+  public_key = {
+    RSA   = var.public_key_pem
+    SMIME = var.cert_pem
+  }
+}
 module "encrypt" {
   source  = "matti/resource/shell"
   version = "1.1.0"
   environment = {
-    PUBLIC_KEY_PEM = var.public_key_pem
+    PUBLIC_KEY_PEM = local.public_key[var.algorithm]
   }
   sensitive_environment = {
     CONTENT_B64 = var.content_base64
@@ -11,8 +21,7 @@ module "encrypt" {
   command = <<-EOF
     public_key_pem_file=$(mktemp)
     printenv PUBLIC_KEY_PEM > $public_key_pem_file
-    printenv CONTENT_B64 | base64 -d | openssl rsautl -encrypt -pubin -inkey $public_key_pem_file | base64 --wrap=0
+    printenv CONTENT_B64 | base64 -d | openssl ${local.openssl_command[var.algorithm]} | base64 --wrap=0
     rm -f $public_key_file
   EOF
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "result" {
-  description = "Encrypted content in Base64-encoded format."
+  description = "The base64-encoded encrypted content."
   value       = [module.encrypt.stdout][module.encrypt.exitstatus]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,22 @@
+variable "algorithm" {
+  type        = string
+  description = "The OpenSSL algorithm to use, RSA or SMIME."
+  default     = "RSA"
+  validation {
+    condition     = contains(["RSA", "SMIME"], var.algorithm)
+    error_message = "The algorithm must be either RSA or SMIME."
+  }
+}
 variable "public_key_pem" {
   type        = string
   description = "The RSA public key to use for encryption."
+  default     = null
 }
-
+variable "cert_pem" {
+  type        = string
+  description = "The (self-)signed certificate if using SMIME."
+  default     = null
+}
 variable "content_base64" {
   type        = string
   description = "Base64-encoded data to be encrypted."

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "algorithm" {
   type        = string
-  description = "The OpenSSL algorithm to use, RSA or SMIME."
+  description = "The algorithm to use, RSA or SMIME."
   default     = "RSA"
   validation {
     condition     = contains(["RSA", "SMIME"], var.algorithm)


### PR DESCRIPTION
## what
Add ability to encrypt content_base64 using SMIME.

## why
RSA public key encryption only supports encrypting content that is smaller than the key size, e.g. a 2048-bit RSA key can only encrypt up to about 245 bytes using v1.5 padding.
SMIME does not have this limitation.

## references
* https://www.xspdf.com/resolution/53205056.html