### PR TITLE
Can run this module under Alpine / Busybox

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ module "encrypt" {
   command = <<-EOF
     public_key_pem_file=$(mktemp)
     printenv PUBLIC_KEY_PEM > $public_key_pem_file
-    printenv CONTENT_B64 | base64 -d | openssl ${local.openssl_command[var.algorithm]} | base64 --wrap=0
+    printenv CONTENT_B64 | base64 -d | openssl ${local.openssl_command[var.algorithm]} | base64
     rm -f $public_key_file
   EOF
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "result" {
   description = "The base64-encoded encrypted content."
-  value       = [module.encrypt.stdout][module.encrypt.exitstatus]
+  value       = [replace(module.encrypt.stdout, "\n", "")][module.encrypt.exitstatus]
 }


### PR DESCRIPTION
## Describe the Bug
base64 --wrap=0 does not exist on alpine.

## Expected Behavior
That the module would work.

## Steps to Reproduce
Run example/complete under alpine box

## Screenshots
```
resource "null_resource" "contents_if_missing" {
      - id       = "6203836822046158938" -> null
      - triggers = {
          - "exitstatus" = "0"
          - "stderr"     = <<~EOT
                base64: unrecognized option: wrap=0
                BusyBox v1.31.1 () multi-call binary.
                
                Usage: base64 [-d] [FILE]
                
                Base64 encode or decode FILE to standard output
                	-d	Decode data
            EOT
          - "stdout"     = ""
        } -> null
    }
```
## Environment (please complete the following information):

Anything that will help us triage the bug will help. Here are some ideas:
 - OS: Alpine + BusyBox
 - Version [e.g. 10.15]

## Additional Context
Add any other context about the problem here.